### PR TITLE
Support bzip files with multiple blocks

### DIFF
--- a/xfile_parser.py
+++ b/xfile_parser.py
@@ -112,7 +112,6 @@ class XFileParser(object):
                 est_out += MSZIP_BLOCK
 
             # Allocate storage and terminating zero and do the actual uncompressing
-            uncompressedEnd = 0
             uncompressed = bytearray()
             while self.p + 3 < self.end:
                 ofs = struct.unpack_from('H', self.buffer, self.p)[0]
@@ -121,10 +120,9 @@ class XFileParser(object):
                     raise Exception("X: Unexpected EOF in compressed chunk")
                 z = zlib.decompressobj(wbits=-15, zdict=uncompressed)
                 uncompressed += z.decompress(self.buffer[self.p:])
-                uncompressedEnd += len(uncompressed)
                 self.p += ofs
             self.buffer = uncompressed
-            self.end = uncompressedEnd
+            self.end = len(uncompressed)
             self.p = 0
         else:
             self.ReadUntilEndOfLine()

--- a/xfile_parser.py
+++ b/xfile_parser.py
@@ -113,13 +113,14 @@ class XFileParser(object):
 
             # Allocate storage and terminating zero and do the actual uncompressing
             uncompressedEnd = 0
+            uncompressed = bytearray()
             while self.p + 3 < self.end:
                 ofs = struct.unpack_from('H', self.buffer, self.p)[0]
                 self.p += 4
                 if self.p + ofs > self.end + 2:
                     raise Exception("X: Unexpected EOF in compressed chunk")
-                uncompressed = zlib.decompress(
-                    self.buffer[self.p:], -8, MSZIP_BLOCK)
+                z = zlib.decompressobj(wbits=-15, zdict=uncompressed)
+                uncompressed += z.decompress(self.buffer[self.p:])
                 uncompressedEnd += len(uncompressed)
                 self.p += ofs
             self.buffer = uncompressed


### PR DESCRIPTION
Previousely trying to decompress files with multiple compressed blocks resulted in the error:  zlib.error: Error -3 while decompressing data: invalid distance too far back. By changing wbits to -15 and adding a predefined compression dictionary from the already extracted data the issue should be fixed.